### PR TITLE
Shard crossbuild image, also generate squashfs images

### DIFF
--- a/crossbuild/Makefile
+++ b/crossbuild/Makefile
@@ -106,19 +106,19 @@ shards: /tmp/rootfs
 		rm -rf $${f}; \
 	done; \
 	echo "Packaging tar.gz rootfs base..."; \
-	GZIP=-9 tar zcf /tmp/rootfs.tar.gz -C $< .; \
+	GZIP=-9 tar zcf /tmp/rootfs-base.tar.gz -C $< .; \
 	echo "Packaging squashfs rootfs base..."; \
-	mksquashfs $< /tmp/rootfs.squashfs $(SQUASHFS_OPTS); \
+	mksquashfs $< /tmp/rootfs-base.squashfs $(SQUASHFS_OPTS); \
 	echo "Checksumming..."; \
-	shasum -a 256 /tmp/rootfs.tar.gz | cut -d' ' -f1 > /tmp/rootfs.tar.gz.sha256; \
-	shasum -a 256 /tmp/rootfs.squashfs | cut -d' ' -f1 > /tmp/rootfs.squashfs.sha256; \
+	shasum -a 256 /tmp/rootfs-base.tar.gz | cut -d' ' -f1 > /tmp/rootfs-base.tar.gz.sha256; \
+	shasum -a 256 /tmp/rootfs-base.squashfs | cut -d' ' -f1 > /tmp/rootfs-base.squashfs.sha256; \
 	echo "Final cleanup..."; \
 	rm -rf /tmp/rootfs
 
 push-rootfs: shards
 	@echo "Uploading to S3..."
 	@ DATE_STR=$$(date +%Y-%m-%d); \
-	for f in /tmp/rootfs*.tar.gz; do \
+	for f in /tmp/rootfs-*.tar.gz; do \
 		f_tarball=$${f}; \
 		f_squashfs=$${f%.*.*}.squashfs; \
 		f_prefix=$$(basename $${f%.*.*}); \

--- a/crossbuild/Makefile
+++ b/crossbuild/Makefile
@@ -85,7 +85,11 @@ $(foreach f,$(HFS),$(eval $(call build_dockerfile,$(f))))
 	touch $@/dev/ptmx; \
 	rm -rf $@/usr/share/terminfo; \
 	echo "Removing OSX SDK..."; \
-	rm -rf $@/opt/x86_64-apple-darwin14/MacOSX*.sdk
+	rm -rf $@/opt/x86_64-apple-darwin14/MacOSX*.sdk; \
+	echo "Overwriting resolv.conf..."; \
+	echo "nameserver 8.8.8.8"  > $@/etc/resolv.conf; \
+	echo "nameserver 8.8.4.4" >> $@/etc/resolv.conf; \
+	echo "nameserver 4.4.4.4" >> $@/etc/resolv.conf
 
 # Package 'em all up
 SQUASHFS_OPTS=-force-uid 1000 -force-gid 1000 -comp xz -b 1048576 -Xdict-size 100%

--- a/crossbuild/Makefile
+++ b/crossbuild/Makefile
@@ -92,7 +92,7 @@ $(foreach f,$(HFS),$(eval $(call build_dockerfile,$(f))))
 	echo "nameserver 4.4.4.4" >> $@/etc/resolv.conf
 
 # Package 'em all up
-SQUASHFS_OPTS=-force-uid 1000 -force-gid 1000 -comp xz -b 1048576 -Xdict-size 100%
+SQUASHFS_OPTS=-force-uid 0 -force-gid 0 -comp xz -b 1048576 -Xdict-size 100%
 shards: /tmp/rootfs
 	@ echo "Repackaging..."; \
 	for f in $</opt/*-*-*; do \

--- a/crossbuild/Makefile
+++ b/crossbuild/Makefile
@@ -133,7 +133,6 @@ push-rootfs: shards
 print-hashes:
 	@# Print out the squashfs hashes first
 	@echo "    squashfs_hashes = Dict("
-	@echo "        \"base\" => \"$$(cat /tmp/rootfs.squashfs.sha256)\""
 	@for f in /tmp/rootfs-*.squashfs; do \
 		f_prefix=$$(basename $${f%.*}); \
 		triplet=$${f_prefix:7}; \
@@ -142,7 +141,6 @@ print-hashes:
 	@echo "    )"
 	@# Then print out the tarball hashes:
 	@echo "    tarball_hashes = Dict("
-	@echo "        \"base\" => \"$$(cat /tmp/rootfs.tar.gz.sha256)\""
 	@for f in /tmp/rootfs-*.tar.gz; do \
 		f_prefix=$$(basename $${f%.*.*}); \
 		triplet=$${f_prefix:7}; \

--- a/crossbuild/Makefile
+++ b/crossbuild/Makefile
@@ -23,13 +23,16 @@ patches:
 define build_dockerfile
 # Running just `make build-crossbuild-x64` will build that image
 build-$(1): build/$(1)/Dockerfile
+	docker build --pull -t $(call crossbuild_tag_name,$(1)) "build/$(1)"
+
+buildsquash-$(1): build/$(1)/Dockerfile
 	$(DOCKER_BUILD) --pull -t $(call crossbuild_tag_name,$(1)) "build/$(1)"
 
 shell-$(1):
 	docker run -ti $(call crossbuild_tag_name,$(1))
 
 # Running `make push-ubuntu16_04-x86` will upload that image to
-push-$(1):
+push-$(1): buildsquash-$(1)
 	docker push $(call crossbuild_tag_name,$(1))
 
 # This is how we build the actual Dockerfile
@@ -68,36 +71,84 @@ $(foreach f,$(HFS),$(eval $(call build_dockerfile,$(f))))
 	echo "Exporting..."; \
 	docker export $$CONTAINER_ID -o $@; \
 	echo "Stopping container..."; \
-	docker stop $$CONTAINER_ID
+	docker stop $$CONTAINER_ID >/dev/null
 
-# We need to remove special files that we can't extract properly on
-# host platforms here
-/tmp/rootfs.tar.gz: /tmp/rootfs.tar
+# Extract and cleanup the rootfs
+/tmp/rootfs: /tmp/rootfs.tar
 	@echo "Unpacking..."; \
-	rm -rf /tmp/rootfs; \
-	mkdir -p /tmp/rootfs; \
-	tar xf $< -C /tmp/rootfs; \
-   	echo "Beginning cleanup operations..."; \
-	rm -f /tmp/rootfs/dev/null; \
-	touch /tmp/rootfs/dev/null; \
-	touch /tmp/rootfs/dev/ptmx; \
-	rm -rf /tmp/rootfs/usr/share/terminfo; \
-	echo "Repackaging..."; \
-	GZIP=-9 tar zcf $@ -C /tmp/rootfs .; \
+	rm -rf $@; \
+	mkdir -p $@; \
+	tar xf $< -C $@; \
+	echo "Cleaning up $@..."; \
+	rm -f $@/dev/null; \
+	touch $@/dev/null; \
+	touch $@/dev/ptmx; \
+	rm -rf $@/usr/share/terminfo; \
+	echo "Removing OSX SDK..."; \
+	rm -rf $@/opt/x86_64-apple-darwin14/MacOSX*.sdk
+
+# Package 'em all up
+SQUASHFS_OPTS=-force-uid 1000 -force-gid 1000 -comp xz -b 1048576 -Xdict-size 100%
+shards: /tmp/rootfs
+	@ echo "Repackaging..."; \
+	for f in $</opt/*-*-*; do \
+		f_target=$$(basename $${f}); \
+		f_out=/tmp/rootfs-$${f_target}; \
+		rm -f $${f_out}.tar.gz $${f_out}.squashfs; \
+		echo "  Packaging tar.gz $${f_target} shard from $${f}..."; \
+		GZIP=-9 tar zcf $${f_out}.tar.gz -C $${f}  .; \
+		echo "  Packaging squashfs $${f_target} shard from $${f}..."; \
+		mksquashfs $${f} $${f_out}.squashfs $(SQUASHFS_OPTS); \
+		echo "  Checksumming..."; \
+		shasum -a 256 $${f_out}.tar.gz | cut -d' ' -f1 > $${f_out}.tar.gz.sha256; \
+		shasum -a 256 $${f_out}.squashfs | cut -d' ' -f1 > $${f_out}.squashfs.sha256; \
+		echo "  Removing $${f_target} from unpacked directory..."; \
+		rm -rf $${f}; \
+	done; \
+	echo "Packaging tar.gz rootfs base..."; \
+	GZIP=-9 tar zcf /tmp/rootfs.tar.gz -C $< .; \
+	echo "Packaging squashfs rootfs base..."; \
+	mksquashfs $< /tmp/rootfs.squashfs $(SQUASHFS_OPTS); \
+	echo "Checksumming..."; \
+	shasum -a 256 /tmp/rootfs.tar.gz | cut -d' ' -f1 > /tmp/rootfs.tar.gz.sha256; \
+	shasum -a 256 /tmp/rootfs.squashfs | cut -d' ' -f1 > /tmp/rootfs.squashfs.sha256; \
 	echo "Final cleanup..."; \
 	rm -rf /tmp/rootfs
 
-/tmp/rootfs.tar.gz.sha256: /tmp/rootfs.tar.gz
-	@shasum -a 256 $< | cut -d' ' -f1 > $@
-
-push-rootfs: /tmp/rootfs.tar.gz /tmp/rootfs.tar.gz.sha256
+push-rootfs: shards
 	@echo "Uploading to S3..."
 	@ DATE_STR=$$(date +%Y-%m-%d); \
-	aws s3 cp --acl public-read /tmp/rootfs.tar.gz s3://julialangmirror/binarybuilder-rootfs-$${DATE_STR}.tar.gz; \
-	aws s3 cp --acl public-read /tmp/rootfs.tar.gz.sha256 s3://julialangmirror/binarybuilder-rootfs-$${DATE_STR}.tar.gz.sha256; \
-	echo "URL: https://julialangmirror.s3.amazonaws.com/binarybuilder-rootfs-$${DATE_STR}.tar.gz"; \
-	echo "hash: $$(cat /tmp/rootfs.tar.gz.sha256)"
+	for f in /tmp/rootfs*.tar.gz; do \
+		f_tarball=$${f}; \
+		f_squashfs=$${f%.*.*}.squashfs; \
+		f_prefix=$$(basename $${f%.*.*}); \
+		s3_prefix="s3://julialangmirror/binarybuilder"; \
+		url_prefix="https://julialangmirror.s3.amazonaws.com/binarybuilder"; \
+		aws s3 cp --acl public-read $${f_tarball} $${s3_prefix}-$${f_prefix}-$${DATE_STR}.tar.gz; \
+		aws s3 cp --acl public-read $${f_squashfs} $${s3_prefix}-$${f_prefix}-$${DATE_STR}.squashfs; \
+		aws s3 cp --acl public-read $${f_tarball}.sha256 $${s3_prefix}-$${f_prefix}-$${DATE_STR}.tar.gz.sha256; \
+		aws s3 cp --acl public-read $${f_squashfs}.sha256 $${s3_prefix}-$${f_prefix}-$${DATE_STR}.squashfs.sha256; \
+	done
 
+print-hashes:
+	@# Print out the squashfs hashes first
+	@echo "    squashfs_hashes = Dict("
+	@echo "        \"base\" => \"$$(cat /tmp/rootfs.squashfs.sha256)\""
+	@for f in /tmp/rootfs-*.squashfs; do \
+		f_prefix=$$(basename $${f%.*}); \
+		triplet=$${f_prefix:7}; \
+		echo "        \"$${triplet}\" => \"$$(cat $${f}.sha256)\","; \
+	done
+	@echo "    )"
+	@# Then print out the tarball hashes:
+	@echo "    tarball_hashes = Dict("
+	@echo "        \"base\" => \"$$(cat /tmp/rootfs.tar.gz.sha256)\""
+	@for f in /tmp/rootfs-*.tar.gz; do \
+		f_prefix=$$(basename $${f%.*.*}); \
+		triplet=$${f_prefix:7}; \
+		echo "        \"$${triplet}\" => \"$$(cat $${f}.sha256)\","; \
+	done
+	@echo "    )"
 
 
 clean:

--- a/crossbuild/crossbuild-x64.harbor
+++ b/crossbuild/crossbuild-x64.harbor
@@ -98,14 +98,17 @@ RUN rm -rf /downloads /build.sh
 RUN apk del ${TEMPORARY_DEPS}
 RUN apk add libstdc++ libgcc
 
+# Also install glibc, to do so we need to first import a packaging key
+RUN curl -q -# -L https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub
+RUN curl -q -# -L https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.26-r0/glibc-2.26-r0.apk -o /tmp/glibc.apk
+RUN apk add /tmp/glibc.apk
+RUN rm -f /tmp/glibc.apk
+
 # Use /entrypoint.sh to conditionally apply ${L32} since we can't use ARG
 # values within an actual ENTRYPOINT command.  :(
 RUN echo "#!/bin/bash" > /entrypoint.sh; \
     echo "${L32} \"\$@\"" >> /entrypoint.sh; \
     chmod +x /entrypoint.sh
-RUN echo "nameserver 8.8.8.8" > /etc/resolv.conf; \
-    echo "nameserver 8.8.4.4" >> /etc/resolv.conf; \
-    echo "nameserver 4.4.4.4" >> /etc/resolv.conf
 
 # Set default workdir
 WORKDIR /workspace

--- a/crossbuild/crossbuild-x64.harbor
+++ b/crossbuild/crossbuild-x64.harbor
@@ -79,7 +79,9 @@ INCLUDE lib/binutils_install
 # Install CMake toolchain files and patch CMake defaults
 WORKDIR /
 COPY cmake_toolchains /downloads/cmake_toolchains
-RUN cp /downloads/cmake_toolchains/* /opt
+RUN for f in /downloads/cmake_toolchains/*; do \
+        cp -v $f /opt/$(basename ${f%.*})/; \
+    done
 RUN patch -p0 < /downloads/patches/cmake_install.patch
 
 # Override normal uname with something that fakes out based on ${target}

--- a/workerbase/lib/wine_install.harbor
+++ b/workerbase/lib/wine_install.harbor
@@ -1,3 +1,8 @@
+USER root
+# Install libpng
+RUN [[ -n "$(which yum 2>/dev/null)" ]] && yum install -y libpng-devel || true
+RUN [[ -n "$(which apt-get 2>/dev/null)" ]] && apt-get install -y libpng-dev || true
+
 USER buildworker
 WORKDIR /src
 
@@ -5,10 +10,14 @@ ARG wine_version=2.0.3
 
 RUN git clone https://github.com/wine-mirror/wine.git -b wine-${wine_version}
 WORKDIR /src/wine
-RUN ${L32} ./configure --without-x --without-freetype --enable-win64
+RUN ${L32} ./configure --without-x --without-freetype --enable-win64 --with-png
 RUN ${L32} make -j3
 
 USER root
 RUN ${L32} make install
 WORKDIR /src
 RUN rm -rf wine
+
+# Wine installs under `wine64`, but we still want it available via `wine`
+RUN [[ -f /usr/local/bin/wine64 ]] && ln -s /usr/local/bin/wine64 /usr/local/bin/wine
+


### PR DESCRIPTION
Supercedes https://github.com/staticfloat/julia-docker/pull/8, this generates multiple, smaller `.tar.gz` (and `.squashfs`, which actually gives us a nice total download size reduction from 3.8GB -> 2.4GB) files per-triplet, as well as an overall "base" image.  I'm still working on the Julia-side code for this, but here's the build infrastructural support required.